### PR TITLE
Fix Portuguese translation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Fix Portuguese translation issues ([#72](https://github.com/brightlayer-ui/react-auth-shared/issues/72)).
+-   Fix Portuguese translation issues ([#74](https://github.com/brightlayer-ui/react-auth-shared/issues/74)).
 
 ## v3.7.0 (April 26, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.7.1 (unreleased)
+## v3.7.1 (August 4, 2022)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Add `VERIFICATION_CODE_PROMPT` translations.
 
+### Fixed
+
+-   Fix Portuguese translation issues ([#72](https://github.com/brightlayer-ui/react-auth-shared/issues/72)).
+
 ## v3.7.0 (April 26, 2022)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-auth-shared",
     "description": "Re-usable react logic for Authentication and Registration within Eaton applications. For use with @brightlayer-ui/react-native-auth-workflow and @brightlayer-ui/react-auth-workflow.",
-    "version": "3.7.1-beta.0",
+    "version": "3.7.1",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",

--- a/src/data/translations/portuguese.ts
+++ b/src/data/translations/portuguese.ts
@@ -88,7 +88,7 @@ const resources: LanguageFile = {
             ERROR: 'De momento, não foi possível redefinir a sua palavra-passe.',
             INSTRUCTIONS:
                 'Por favor, insira o e-mail associado com a conta.\n\n' +
-                'Se este e-mail tem uma conta com a Eaton, irá receber uma resposta dentro de <1>um dia útil</1>.<br/><br/>' +
+                'Se este e-mail tem uma conta com a Eaton, irá receber uma resposta dentro de <1>um dia útil</1>.\n\n' +
                 'Para assuntos urgentes relacionados com a sua conta, por favor contacte <4>{{phone}}</4>.',
             INSTRUCTIONS_ALT:
                 'Por favor, insira o e-mail associado com a conta.<br/><br/>' +
@@ -152,7 +152,7 @@ const resources: LanguageFile = {
                 'A sua palavra-passe foi atualizada! Para assegurar a segurança da sua conta, terá de iniciar sessão na aplicação com as suas credenciais atualizadas.',
             EMAIL_CONFIRM_MESSAGE: 'Enviámos um e-mail de confirmação para <b>{{email}}</b>',
             PASSWORD_INFO:
-                'Por favor selecione uma palavra-passe. Make sure that your password meets the necessary complexity requirements outlined below.',
+                'Por favor selecione uma palavra-passe. Certifique-se de que sua senha atenda aos requisitos de complexidade necessários descritos abaixo.',
             OLD_PASSWORD: 'Palavra-passe anterior',
             ERROR_MESSAGE:
                 'A sua informação não corresponde aos nossos registos. Por favor, confirme as informações e tente de novo.',
@@ -177,7 +177,7 @@ const resources: LanguageFile = {
         },
         CONTACT_SUPPORT: {
             GENERAL_QUESTIONS: 'Questões Gerais',
-            SUPPORT_MESSAGE: 'Para questões, comentários, ou apoio técnico, por favor envie um e-mail para',
+            SUPPORT_MESSAGE: 'Para questões, comentários, ou apoio técnico, por favor envie um e-mail para ',
             EMERGENCY_SUPPORT: 'Apoio de Emergência',
             TECHNICAL_ASSISTANCE: 'Para apoio técnico, por favor contacte ',
         },


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #74.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Replace `<br/><br/>` tag rendering on the forgot password screen with `/n/n`
- Add a space between the contact us text and the provided email address
- Translate CHANGE_PASSWORD.PASSWORD_INFO

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- 
