### PR TITLE
Move optional ref prop from AccountDetailsFormProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.7.4 (October 28, 2022)
+
+### Changed
+
+-   Moved optional `ref` prop from `AccountDetailsFormProps` to new `AccountDetailsFormMobileProps` type definition.
+
 ## v3.7.3 (October 28, 2022)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.7.4 (October 28, 2022)
+## v3.7.4 (unreleased)
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-auth-shared",
     "description": "Re-usable react logic for Authentication and Registration within Eaton applications. For use with @brightlayer-ui/react-native-auth-workflow and @brightlayer-ui/react-auth-workflow.",
-    "version": "3.7.3",
+    "version": "3.7.4-alpha.0",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",
@@ -64,7 +64,7 @@
         "@types/enzyme-adapter-react-16": "^1.0.6",
         "@types/jest": "^26.0.0",
         "@types/node": "^14.0.0",
-        "@types/react-native": "^0.70.0",
+        "@types/react-native": "^0.70.7",
         "@types/react-test-renderer": "^17.0.0",
         "@typescript-eslint/eslint-plugin": "^4.0.0",
         "@typescript-eslint/parser": "^4.0.0",

--- a/src/types/AccountDetails.tsx
+++ b/src/types/AccountDetails.tsx
@@ -17,7 +17,7 @@ export type AccountDetailsFormProps = {
     onDetailsChanged: (details: CustomAccountDetails | null, valid: boolean) => void;
     initialDetails?: CustomAccountDetails;
     onSubmit?: () => void;
-}
+};
 
 export type RegistrationData = {
     accountDetails?: AccountDetailInformation | null | undefined;

--- a/src/types/AccountDetails.tsx
+++ b/src/types/AccountDetails.tsx
@@ -1,5 +1,3 @@
-import { TextInput } from 'react-native';
-
 /**
  * Type to represent the input of the account details component.
  *
@@ -19,8 +17,7 @@ export type AccountDetailsFormProps = {
     onDetailsChanged: (details: CustomAccountDetails | null, valid: boolean) => void;
     initialDetails?: CustomAccountDetails;
     onSubmit?: () => void;
-    ref?: React.RefObject<TextInput>;
-};
+}
 
 export type RegistrationData = {
     accountDetails?: AccountDetailInformation | null | undefined;

--- a/src/types/AccountDetailsMobile.tsx
+++ b/src/types/AccountDetailsMobile.tsx
@@ -1,0 +1,6 @@
+import { TextInput } from 'react-native';
+import { AccountDetailsFormProps } from './AccountDetails';
+
+export type AccountDetailsFormMobileProps = AccountDetailsFormProps & {
+    ref?: React.RefObject<TextInput>;
+};

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,4 +1,5 @@
 export * from './AccountDetails';
+export * from './AccountDetailsMobile';
 export * from './ContactParams';
 export * from './ResetPasswordParams';
 export * from './TextInputHTMLAttributes';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,10 +1649,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
 
-"@types/react-native@^0.70.0":
-  version "0.70.6"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.70.6.tgz#0d1bc3014111f64f13e0df643aec2ab03f021fdb"
-  integrity sha512-ynQ2jj0km9d7dbnyKqVdQ6Nti7VQ8SLTA/KKkkS5+FnvGyvij2AOo1/xnkBR/jnSNXuzrvGVzw2n0VWfppmfKw==
+"@types/react-native@^0.70.7":
+  version "0.70.7"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.70.7.tgz#1708e5f746bbce2ea4e0bd5a2627560667804d46"
+  integrity sha512-hBzeUWwk8sfj3vDfwEXb4hbjWjl0jb5CvWlu2gLrOUJyFHVzJ+x6Y9ilO2eVtJW7l5QmmNLILE1PkVfKRkqYuQ==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes an issue where react workflows is trying to import a react-native-dependency. I'm separating the type definitions for now so react-workflows isn't forced to use react-native modules.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Move optional ref prop from `AccountDetailsFormProps` to `AccountDetailsFormMobileProps` type definition

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Run react-login-workflow example project from the `bug/170-remove-mui-styles` branch and ensure the account details pages work in the registration workflows
- Run react-native-login-workflow example project from the `bug/update-imports-to-use-latest-auth-shared-type` branch and ensure the account details pages work in the registration workflows
